### PR TITLE
remove quotes and add generic "/command"

### DIFF
--- a/google-assistant-webserver/config.json
+++ b/google-assistant-webserver/config.json
@@ -1,6 +1,6 @@
 {
   "name": "Google Assistant Webserver",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "slug": "google_assistant_webserver",
   "description": "A virtual personal assistant developed by Google (text input via webserver). Once running and authenticated, you can send a GET request to http://hassio.local:5000/broadcast_message?message=[MESSAGE] to broadcast a text message to all your Google Assistants.",
   "url": "https://github.com/AndBobsYourUncle/hassio-addons/",

--- a/google-assistant-webserver/hassio_gassistant.py
+++ b/google-assistant-webserver/hassio_gassistant.py
@@ -28,11 +28,21 @@ DEFAULT_GRPC_DEADLINE = 60 * 3 + 5
 class BroadcastMessage(Resource):
     def get(self):
         message = request.args.get('message', default = 'This is a test!')
-        text_query = 'broadcast "'+message+'"'
+        text_query = 'broadcast '+message+''
         display_text = assistant.assist(text_query=text_query)
         return {'status': 'OK'}
 
 api.add_resource(BroadcastMessage, '/broadcast_message')
+
+class Command(Resource):
+    def get(self):
+        message = request.args.get('message', default = 'This is a test!')
+        text_query = ''+message+''
+        display_text = assistant.assist(text_query=text_query)
+        return {'status': 'OK'}
+
+api.add_resource(Command, '/command')
+
 
 class GoogleTextAssistant(object):
     """Assistant that supports text based conversations.

--- a/google-assistant-webserver/hassio_gassistant.py
+++ b/google-assistant-webserver/hassio_gassistant.py
@@ -28,7 +28,7 @@ DEFAULT_GRPC_DEADLINE = 60 * 3 + 5
 class BroadcastMessage(Resource):
     def get(self):
         message = request.args.get('message', default = 'This is a test!')
-        text_query = 'broadcast '+message+''
+        text_query = 'broadcast '+message
         display_text = assistant.assist(text_query=text_query)
         return {'status': 'OK'}
 
@@ -37,8 +37,7 @@ api.add_resource(BroadcastMessage, '/broadcast_message')
 class Command(Resource):
     def get(self):
         message = request.args.get('message', default = 'This is a test!')
-        text_query = ''+message+''
-        display_text = assistant.assist(text_query=text_query)
+        display_text = assistant.assist(text_query=message)
         return {'status': 'OK'}
 
 api.add_resource(Command, '/command')


### PR DESCRIPTION
Quotes don't allow "special" responses for "Broadcast Dinner Time" and others. If non-special responses preferred simply wrap in quotes: Broadcast "Dinner Time" and Google will respond with TTS.

Generic api resource ("/command") allows other commands.