### PR TITLE
resp.dialog_state_out.supplemental_display_text isn't a function

### DIFF
--- a/google-assistant-webserver/hassio_gassistant.py
+++ b/google-assistant-webserver/hassio_gassistant.py
@@ -129,7 +129,7 @@ class GoogleTextAssistant(object):
                 conversation_state = resp.dialog_state_out.conversation_state
                 self.conversation_state = conversation_state
             if resp.dialog_state_out.supplemental_display_text:
-                text_response = resp.dialog_state_out.supplemental_display_text()
+                text_response = resp.dialog_state_out.supplemental_display_text
         return text_response, html_response
 
 if __name__ == '__main__':


### PR DESCRIPTION
resp.dialog_state_out.supplemental_display_text isn't a function, so it should not be called like that.

See https://github.com/googlesamples/assistant-sdk-python/blob/master/google-assistant-sdk/googlesamples/assistant/grpc/textinput.py#L120