### PR TITLE
Update config USPS to HA supervisor 2021.2

### DIFF
--- a/usps-tracker/config.json
+++ b/usps-tracker/config.json
@@ -5,7 +5,7 @@
   "description": "This addon spins up a simple Ruby server that logs in and downloads emails from the USPS Informed Delivery service, and manages a list of incoming packages.",
   "arch": ["armhf", "armv7", "aarch64", "amd64", "i386"],
   "map": ["share"],
-  "startup": "before",
+  "startup": "application",
   "boot": "auto",
   "options": {},
   "schema": {},


### PR DESCRIPTION
Should fix:

`21-02-25 15:51:09 WARNING (MainThread) [supervisor.addons.validate] Add-on config 'startup' with 'before' is deprecated. Please report this to the maintainer of USPS Package Tracker`